### PR TITLE
Add support for /etc/hans.conf configuration directives

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,8 @@
+Release 1.2 (August 2024)
+-------------------------
+* Added support for configuration files, and added /etc/hans.conf as an example [Randolf Richardson]
+* Documented /etc/hans.conf (in configuration file comments) [Randolf Richardson]
+
 Release 1.1 (November 2022)
 ---------------------------
 * Switch to utun devices on macOS (thanks to unkernet)

--- a/etc/hans.conf
+++ b/etc/hans.conf
@@ -1,0 +1,115 @@
+# HANS - IP over ICMP by Friedrich Schöller
+# https://code.gerade.org/hans/
+#
+# Server daemon configuration file implementation and
+# documentation by Randolf Richardson (August 10, 2024)
+# https://www.randolf.ca/
+#
+# Source code repositories:
+#   https://www.sourceforge.net/projects/hanstunnel/files/source/
+#   https://www.github.com/friedrich/hans
+#
+# Note:  Directives and their values are case-sensitive.
+#
+
+# For clients, specify the IP address or host of the server that
+# you're connecting to:
+#
+#    Client <ip-address-or-hostname>
+#
+# (Use either the "Client" or "Server" directive to configure
+# HANS accordingly.)
+#
+Client hans-server.example.com
+
+# For servers, specify the IP address of the internal /24
+# network to use (this network will be extended to clients, who
+# will each be assigned an IP address automatically via DHCP):
+#
+#    Server <ip-address-or-hostname>
+#
+# (Use either the "Client" or "Server" directive to configure
+# HANS accordingly.)
+#
+#Server 10.4.0.1
+
+# Using a passphrase is essential as a means to preventing
+# unauthorized clients from connecting and accessing your
+# network (you should also limit which clients can connect to
+# your server by using firewall rules to block all except for
+# those public IP addresses that your users are known to
+# connect from).
+#
+#    Passphrase <password>
+#
+Passphrase radio-active_cats_have_18_half-lives
+
+# Make HANS run under the specified user (downgrade from root).
+#
+#    Username <username>
+#
+#Username nobody
+
+# Request a specific IP address be assigned by the HANS' DHCP
+# server.
+#
+#    RequestIP <ip-address>
+#
+#RequestIP 10.4.0.42
+
+# Respond to ordinary ICMP ping requests in server mode.
+#
+#    RespondToPing < Yes | On | 1 | No | Off | 0 >
+#
+#RespondToPing No
+
+# Specify which network interface device to use.
+#
+#    Device <tun-device-name>
+#
+#Device tun0
+
+# Set the maximum size of echo packets.
+#
+# Default:  1500
+#
+#    MTU <integer>
+#
+#MTU 1500
+
+# Number of echo requests clients send in advance for the server
+# to reply to.  0 disabled polling, which is believed to be the
+# best choice in networks that allow unlimited echo replies.
+#
+# Default:  10
+#
+#    MaxPolls <integer>
+#
+#MaxPolls 10
+
+# Change ICMP echo ID on every request.  While this may help
+# with buggy network routers, performance may be impacted.
+#
+#    ChangeEchoID < Yes | On | 1 | No | Off | 0 >
+#
+#ChangeEchoID Off
+
+# Change the ICMP packet Sequence number on every ICMP echo
+# request.  While this may help with buggy network routers,
+# performance may be impacted.
+#
+#    ChangeEchoSequence < Yes | On | 1 | No | Off | 0 >
+#
+#ChangeEchoSequence Off
+
+# Operate in foreground mode.
+#
+#    Verbose < Yes | On | 1 | No | Off | 0 >
+#
+#Foreground Off
+
+# Control verbose output.
+#
+#    Verbose < Yes | On | 1 | No | Off | 0 >
+#
+#Verbose Off


### PR DESCRIPTION
Motivation:  HANS is a fantastic solution, and having directives in /etc/hans.conf makes it more convenient when administering multiple Linux servers.

I added support for reading configuration directives from /etc/hans.conf by default (if it exists), and also added a -F command-line argument to support reading configuration files on-the-fly.

I also created an /etc/hans.conf configuration file, which documents all the directives using inline comments.

I also updated the version number to 1.2 in /src/main.c and in /CHANGES (along with a few notes about these new features).

Please note that I have not tested compilation for MS-Windows, but I don't expect my changes to fail to compile as I've tried to keep the code simple-and-straightforward.  If someone wants to help with this side of things, that would be great.

Thanks!